### PR TITLE
Drop minimum python version to 3.7

### DIFF
--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -21,7 +21,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.7", "3.12"]
         include:
           - os: macos-latest
             python-version: "3.12"

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -19,7 +19,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8"]
+        python-version: ["3.7"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Operating System :: MacOS",
     "Operating System :: POSIX :: Linux",
     "Operating System :: Microsoft :: Windows",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -23,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 
 dependencies = [
     "toml==0.10.2",
@@ -35,7 +36,7 @@ dev = [
     "extremal-python-dependencies[test,lint]",
 ]
 test = [
-    "pytest>=8.0",
+    "pytest>=7.4.4",
 ]
 style = [
     "ruff==0.6.5",
@@ -56,7 +57,7 @@ only-include = [
 ]
 
 [tool.pylint.main]
-py-version = "3.8"
+py-version = "3.7"
 disable = [
     "missing-function-docstring",
 ]


### PR DESCRIPTION
It's already set to 3.7 in tox.ini, so this just brings the rest of the repo in line with that.  We can drop 3.7 support when typer drops it.