### PR TITLE
Attempt to fix #68 using tomllib

### DIFF
--- a/extremal_python_dependencies/main.py
+++ b/extremal_python_dependencies/main.py
@@ -11,6 +11,7 @@
 
 import re
 import configparser
+import tomllib
 from typing import List
 
 import toml
@@ -108,8 +109,8 @@ def get_tox_minversion():
 
 
 def _pin_dependencies(mapfunc, inplace: bool):
-    with open("pyproject.toml", encoding="utf-8") as f:
-        d = toml.load(f)
+    with open("pyproject.toml", "rb") as f:
+        d = tomllib.load(f)
     process_dependencies_in_place(d, mapfunc)
 
     # Modify pyproject.toml so hatchling will allow direct references
@@ -136,8 +137,8 @@ def pin_dependencies(replacements: List[str], inplace: bool = False):
 @app.command()
 def add_dependency(dependency: str, inplace: bool = False):
     """Add a dependency to `pyproject.toml`."""
-    with open("pyproject.toml", encoding="utf-8") as f:
-        d = toml.load(f)
+    with open("pyproject.toml", "rb") as f:
+        d = tomllib.load(f)
     d["project"]["dependencies"].append(dependency)
     _save_pyproject_toml(d, inplace)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,13 +16,12 @@ classifiers = [
     "Operating System :: MacOS",
     "Operating System :: POSIX :: Linux",
     "Operating System :: Microsoft :: Windows",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
 
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 dependencies = [
     "toml==0.10.2",
@@ -56,7 +55,7 @@ only-include = [
 ]
 
 [tool.pylint.main]
-py-version = "3.10"
+py-version = "3.11"
 disable = [
     "missing-function-docstring",
 ]


### PR DESCRIPTION
A brief attempt with using tomllib to parse and toml to write was unsuccessful, and the `toml` library still has difficulty writing the output after being tested on the qiskit-addon-utils pyproject.toml file.

The tomllib library supports reading but not writing.