### PR TITLE
Prepare 0.2.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "extremal-python-dependencies"
-version = "0.1.0"
+version = "0.2.0"
 description = "A utility for installing extremal versions of dependencies for more robust testing"
 readme = "README.md"
 license = {file = "LICENSE.txt"}


### PR DESCRIPTION
This release adds support for PEP 735 dependency groups. Under the hood, it required migrating to tomlkit, which will also result in a better round-trip experience.