### PR TITLE
Add uv to README under "Similar tools"

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ Each of the above patterns can be used in a CI script.
 
 ## Similar tools
 
-- [requirements-builder](https://requirements-builder.readthedocs.io/) (builds requirements from a `setup.py` file instead of a `pyproject.toml` file)
+- [requirements-builder](https://requirements-builder.readthedocs.io/): builds requirements from a `setup.py` file instead of a `pyproject.toml` file
 - [uv](https://docs.astral.sh/uv/)'s [`--resolution` strategies](https://docs.astral.sh/uv/concepts/resolution/#resolution-strategy): `lowest-direct` installs the lowest compatible versions of direct dependencies (similar to the `pin-dependencies` pattern above), while `lowest` extends this to transitive dependencies as well — addressing a [caveat](#caveats) of this tool. If `extremal-python-dependencies` does not meet your needs, `uv` may.

--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ Each of the above patterns can be used in a CI script.
 ## Similar tools
 
 - [requirements-builder](https://requirements-builder.readthedocs.io/) (builds requirements from a `setup.py` file instead of a `pyproject.toml` file)
+- [uv](https://docs.astral.sh/uv/)'s [`--resolution` strategies](https://docs.astral.sh/uv/concepts/resolution/#resolution-strategy): `lowest-direct` installs the lowest compatible versions of direct dependencies (similar to the `pin-dependencies` pattern above), while `lowest` extends this to transitive dependencies as well — addressing a [caveat](#caveats) of this tool. If `extremal-python-dependencies` does not meet your needs, `uv` may.


### PR DESCRIPTION
Adds [uv](https://docs.astral.sh/uv/) to the "Similar tools" section of the README, as requested in #69.

The entry references uv's [`--resolution` strategies](https://docs.astral.sh/uv/concepts/resolution/#resolution-strategy):

- `lowest-direct` — installs the lowest compatible versions of direct dependencies, analogous to the `pin-dependencies` pattern.
- `lowest` — extends this to transitive dependencies as well, which directly addresses the documented [caveat](https://github.com/IBM/extremal-python-dependencies#caveats) that this tool does not set the minimum supported version of transitive dependencies.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)