### PR TITLE
Re-enable pydocstyle and reno lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,8 @@ jobs:
         python-version: ["3.13"]
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:

--- a/extremal_python_dependencies/__init__.py
+++ b/extremal_python_dependencies/__init__.py
@@ -6,3 +6,5 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+
+"""extremal-python-dependencies: install extremal versions of dependencies for robust testing."""

--- a/extremal_python_dependencies/main.py
+++ b/extremal_python_dependencies/main.py
@@ -22,7 +22,7 @@ _name_re = re.compile(r"^([A-Z0-9][A-Z0-9._-]*[A-Z0-9])", re.IGNORECASE)
 
 
 def mapfunc_replace(replacements: List[str]):
-    """Use the provided version(s) of certain packages"""
+    """Use the provided version(s) of certain packages."""
     d: dict[str, str] = {}
     for r in replacements:
         match = _name_re.match(r)
@@ -49,7 +49,7 @@ def mapfunc_replace(replacements: List[str]):
 
 
 def mapfunc_minimum(dep):
-    """Set each dependency to its minimum version"""
+    """Set each dependency to its minimum version."""
     if isinstance(dep, dict) and "include-group" in dep:
         # It's a dependency group include.  Don't touch it.
         return dep
@@ -65,13 +65,13 @@ def mapfunc_minimum(dep):
 
 
 def inplace_map(fun, lst: list):
-    """In-place version of Python's `map` function"""
+    """In-place version of Python's `map` function."""
     for i, x in enumerate(lst):
         lst[i] = fun(x)
 
 
 def process_dependencies_in_place(d: dict, mapfunc):
-    """Given a parsed `pyproject.toml`, process dependencies according to `mapfunc`"""
+    """Given a parsed `pyproject.toml`, process dependencies according to `mapfunc`."""
     proj = d["project"]
 
     try:
@@ -115,7 +115,7 @@ app = typer.Typer()
 
 @app.command()
 def get_tox_minversion():
-    """Extract tox min_version (or minversion) from `tox.ini`"""
+    """Extract tox min_version (or minversion) from `tox.ini`."""
     config = configparser.ConfigParser()
     config.read("tox.ini")
     tox_section = config["tox"]
@@ -170,5 +170,5 @@ def _save_pyproject_toml(d: dict, inplace: bool) -> None:
 
 
 def main():
-    """Main entry point."""
+    """Run the app."""
     return app()  # pragma: no cover

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,0 +1,2 @@
+---
+collapse_pre_releases: true

--- a/tox.ini
+++ b/tox.ini
@@ -26,11 +26,11 @@ commands =
   ruff format --check extremal_python_dependencies/ docs/ test/
   ruff check extremal_python_dependencies/ docs/ test/
   ruff check --preview --select CPY001 extremal_python_dependencies/ test/
-  #pydocstyle extremal_python_dependencies/
+  pydocstyle extremal_python_dependencies/
   mypy extremal_python_dependencies/
   pylint -rn extremal_python_dependencies/ test/
   typos
-  #reno lint
+  reno lint
 
 [testenv:coverage]
 deps =


### PR DESCRIPTION
Closes #5.

## Summary
- Fix docstrings in `main.py` and `__init__.py` to satisfy pydocstyle (missing trailing periods, non-imperative mood in `main()`, missing module docstring)
- Initialize `releasenotes/` with a minimal `reno.yaml`-style config so `reno lint` can run
- Uncomment `pydocstyle` and `reno lint` in `tox.ini`

## Test plan
- [x] `tox -e lint` passes with both linters active
- [x] `tox -e py` tests still pass