### PR TITLE
Add release note for min_version spelling support

### DIFF
--- a/releasenotes/notes/support-min-version-spelling-d9cce49276a301bc.yaml
+++ b/releasenotes/notes/support-min-version-spelling-d9cce49276a301bc.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    The ``get-tox-minversion`` command now accepts both ``min_version`` (the
+    current preferred spelling) and ``minversion`` (the legacy spelling) in
+    ``tox.ini``, preferring ``min_version`` when present.


### PR DESCRIPTION
Adds the release note that was missing from #88.

## Summary
- Adds a `features` release note for the `get-tox-minversion` command accepting both `min_version` and `minversion` spellings

🤖 Generated with [Claude Code](https://claude.com/claude-code)