### PR TITLE
Bump "development status" classifer from alpha -> beta

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "A utility for installing extremal versions of dependencies for mo
 readme = "README.md"
 license = {file = "LICENSE.txt"}
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",


### PR DESCRIPTION
This is used in production, so if anything this is still under-stating things.  We can bump this again when we declare the API stable and release version 1.0.