### PR TITLE
Add Python 3.14 support and clean up tox.ini version list

### DIFF
--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -24,11 +24,11 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.10"
           - os: ubuntu-latest
-            python-version: "3.13"
+            python-version: "3.14"
           - os: macos-latest
-            python-version: "3.13"
+            python-version: "3.14"
           - os: windows-latest
-            python-version: "3.13"
+            python-version: "3.14"
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 requires-python = ">=3.10"

--- a/releasenotes/notes/support-python-3.14-6fff937736de5abc.yaml
+++ b/releasenotes/notes/support-python-3.14-6fff937736de5abc.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Python 3.14 is now officially supported and tested in continuous
+    integration.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.25
-envlist = py{37,38,39,310,311,312,313}, lint, coverage
+envlist = py{310,311,312,313,314}, lint, coverage
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
Declare official support for Python 3.14 and reconcile the tox version list with the actual supported range.

## Changes

- **`pyproject.toml`**: add the `Programming Language :: Python :: 3.14` trove classifier.
- **`tox.ini`**: change the envlist from `py{37,38,39,310,311,312,313}` to `py{310,311,312,313,314}`. The old list still referenced 3.7–3.9 even though `requires-python` has been `>=3.10` for a while; this matches the supported range and adds 3.14.
- **`.github/workflows/test_latest_versions.yml`**: bump the "latest" matrix entries (ubuntu/macOS/Windows) from 3.13 to 3.14. The ubuntu 3.10 entry is retained as the minimum-version check.
- **release note**: add a reno feature note announcing 3.14 support.

## Testing

- `tox -e py` — 41 passed
- `tox -e lint` — clean (ruff, mypy, pylint 10.00/10, typos)
- `reno lint` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)