### PR TITLE
Reduce frequency of dependabot updates to quarterly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,10 @@ updates:
     directory: "/"
     labels: ["dependencies"]
     schedule:
-      interval: "weekly"
+      interval: "quarterly"
   - package-ecosystem: "pip"
     directory: "/"
     labels: ["dependencies"]
     versioning-strategy: increase
     schedule:
-      interval: "monthly"
+      interval: "quarterly"


### PR DESCRIPTION
This should be frequent enough but also reduce the amount of churn in the commit history.