### PR TITLE
Prepare 1.0.0 (stable) release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "hatchling.build"
 
 [project]
 name = "extremal-python-dependencies"
-version = "0.2.1"
+version = "1.0.0"
 description = "A utility for installing extremal versions of dependencies for more robust testing"
 readme = "README.md"
 license = {file = "LICENSE.txt"}
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",


### PR DESCRIPTION
The command-line interface has been stable, and now there is a full test suite (#85).  It seems like a good time to declare that the interface will remain stable as long as the major version number remains the same.  This will allow pinning to major version (only) in CI scripts going forward.